### PR TITLE
fix: run_attempt missing from meta variable

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,6 +1,6 @@
 import sys
 
-from trace import get, generate_trace
+from trace import get, send_trace
 
 # Point this script to the URL of a job and we will trace it
 # You give us this https://github.com/getsentry/sentry/runs/5759197422?check_suite_focus=true
@@ -14,7 +14,7 @@ if __name__ == "__main__":
         req = get(url)
         if not req.ok:
             raise Exception(req.text)
-        generate_trace(req.json())
+        send_trace(req.json())
     else:
         import json
 
@@ -22,4 +22,4 @@ if __name__ == "__main__":
         with open(argument) as f:
             data = json.load(f)
         # XXX: Switch over to handle_event
-        generate_trace(data["workflow_job"])
+        send_trace(data["workflow_job"])

--- a/src/main.py
+++ b/src/main.py
@@ -35,11 +35,6 @@ def handle_event(data, headers):
 def main():
     payload = {"reason": "There was an error."}
     http_code = 500
-    try:
-        payload, http_code = handle_event(request.json, request.headers)
-    except Exception as e:
-        # Report app issue to Sentry
-        capture_exception(e)
-        logging.exception(e)
+    payload, http_code = handle_event(request.json, request.headers)
 
     return jsonify(payload), http_code

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,6 +1,6 @@
-from src.trace import generate_trace
+from src.trace import send_trace
 from .fixtures import *
 
 
 def test_workflow_without_steps(skipped_workflow):
-    assert generate_trace(skipped_workflow) == None
+    assert send_trace(skipped_workflow) == None


### PR DESCRIPTION
There's also removing of few try blocks to make reporting errors to Sentry and the logs less convoluted.